### PR TITLE
Change default timer to use the current time

### DIFF
--- a/tf2_player_joined_notifier_aws/timer.py
+++ b/tf2_player_joined_notifier_aws/timer.py
@@ -15,7 +15,6 @@ def handle_timer_file_not_found(s3_client: BaseClient, sns_client: BaseClient, c
     print("Timer file not found on S3. Creating a new one")
     with open(f"/tmp/{constants.Misc.TIMER_FILE}", "w") as timer_file:
         new_target_time = TimeType()
-        new_target_time.set_time(current_time.current_time_seconds_float + float(convert_minutes_to_seconds(Config.THRESHOLD_TIMER_MINUTES)))
         timer_file.write(str(new_target_time.current_time_seconds_int))
     print(f"Created a new timer file with time {new_target_time.current_time_human_readable}. Uploading it")
     try:


### PR DESCRIPTION
When a timer file didn't exist on S3, it would create one and set the time to be the current time + whatever `timer` value was set in the config. Updated it to simply use the current time so the user doesn't have to wait the full timer duration before receiving a notification.